### PR TITLE
fix leaked threads from unclosed fullnode

### DIFF
--- a/src/fullnode.rs
+++ b/src/fullnode.rs
@@ -673,6 +673,7 @@ mod tests {
             }
         }
         assert!(bootstrap_leader.node_services.tpu.is_leader());
+        bootstrap_leader.close().unwrap();
     }
 
     #[test]


### PR DESCRIPTION
#### Problem
leaked fullnode leaks his tvu which leaks his window service, which causes a crash on exit, preventing code coverage from completing

#### Summary of Changes
close the fullnode

